### PR TITLE
Fix InexactError based on string length

### DIFF
--- a/src/SuffixArrays.jl
+++ b/src/SuffixArrays.jl
@@ -10,9 +10,9 @@ end
 
 function SuffixArray{S}(s::S)
     n = length(s)
-    index = zeros(n < typemax(Int8)  ? Int8  : 
-                  n < typemax(Int16) ? Int16 : 
-                  n < typemax(Int32) ? Int32 : Int64,n)
+    index = zeros(n <= typemax(Int8)  ? Int8  : 
+                  n <= typemax(Int16) ? Int16 : 
+                  n <= typemax(Int32) ? Int32 : Int64, n)
     return SuffixArray(s,n,index)
 end
 

--- a/src/SuffixArrays.jl
+++ b/src/SuffixArrays.jl
@@ -10,9 +10,9 @@ end
 
 function SuffixArray{S}(s::S)
     n = length(s)
-    index = zeros(n < 256 ? Int8 : 
-               n < 65536 ? Int16 : 
-               n < 4294967296 ? Int32 : Int64,n)
+    index = zeros(n < typemax(Int8)  ? Int8  : 
+                  n < typemax(Int16) ? Int16 : 
+                  n < typemax(Int32) ? Int32 : Int64,n)
     return SuffixArray(s,n,index)
 end
 


### PR DESCRIPTION
This fixes the InexactError thrown by strings with length greater than the typemax of a signed int but less than the typemax of the unsigned int (e.g. typemax(Int8) < length(s) <= typemax(UInt8) ):

```julia
julia> SuffixArrays.suffixsort( "BANANA" ^ 21 )
SuffixArrays.SuffixArray{String,Int8}("BANANABANANABANANABANANABANANABANANABANANABANANABANANABANANABANANABANANABANANABANANABANANABANANABANANABANANABANANABANANABANANA",126,Int8[125,119,113,107,101,95,89,83,77,71  …  56,50,44,38,32,26,20,14,8,2])

julia> SuffixArrays.suffixsort( "BANANA" ^ 22 )
ERROR: InexactError()
 in sais(::String, ::Array{Int8,1}, ::Int64, ::Int64, ::Int64, ::Bool) at /Users/timsw/.julia/v0.5/SuffixArrays/src/sais.jl:118
 in suffixsort(::String) at /Users/timsw/.julia/v0.5/SuffixArrays/src/SuffixArrays.jl:25
```