### PR TITLE
return minimal unsigned index types

### DIFF
--- a/src/SuffixArrays.jl
+++ b/src/SuffixArrays.jl
@@ -4,20 +4,36 @@ export suffixsort
 
 const CodeUnits = Union{UInt8,UInt16}
 const IndexTypes = Union{Int8,Int16,Int32,Int64}
-const IndexVector = Vector{<:IndexTypes}
+const IndexVector = AbstractVector{<:IndexTypes}
 
 include("sais.jl")
 
 function suffixsort(V::AbstractVector{U}, base::Integer=1) where {U<:CodeUnits}
+    0 ≤ base || throw(ArgumentError("unsupported negative indexing base: $base"))
     n = length(V)
-    T = n ≤ typemax(Int8)  ? Int8  :
+    # unsigned index type to return
+    T = n+base-1 ≤ typemax(UInt8)  ? UInt8  :
+        n+base-1 ≤ typemax(UInt16) ? UInt16 :
+        n+base-1 ≤ typemax(UInt32) ? UInt32 : UInt64
+    n ≤ 1 && return fill(T(base), n)
+    # signed index type for algorithm
+    S = n ≤ typemax(Int8)  ? Int8  :
         n ≤ typemax(Int16) ? Int16 :
         n ≤ typemax(Int32) ? Int32 : Int64
-    I = zeros(T, n)
-    n ≤ 1 && return I
-    sais(V, I, 0, n, Int(typemax(U))+1, false)
-    base ≠ 0 && (I .+= base)
-    return I
+    if sizeof(T) == sizeof(S)
+        I = zeros(T, n)
+        sais(V, reinterpret(S, I), 0, n, Int(typemax(U))+1, false)
+        base ≠ 0 && (I .+= base)
+        return I
+    else
+        I = zeros(S, n)
+        sais(V, I, 0, n, Int(typemax(U))+1, false)
+        I′ = Vector{T}(undef, n)
+        @inbounds for (i, x) in enumerate(I)
+            I′[i] = (x + base) % T
+        end
+        return I′
+    end
 end
 
 function suffixsort(s::AbstractString, base::Integer=1)


### PR DESCRIPTION
The SAIS algorithm uses negative values but once the suffix array is computed, we can save space by using unsigned types for indices and shrinking the type down to the smallest unsigned type we can. Depending on the length of the array, we may be able to do this by reinterpreting the indices or we may have to copy them.