### PR TITLE
fixes #15 "suffixsort of long array is broken"

### DIFF
--- a/src/sais.jl
+++ b/src/sais.jl
@@ -28,7 +28,7 @@ struct IntVector <: AbstractVector{Int}
     vec::Array{Int,1}
     off::Int
 end
-Base.size(v::IntVector) = size(v.vec)
+Base.size(v::IntVector) = (length(v.vec)-v.off,)
 Base.getindex(v::IntVector, key) = v.vec[v.off+Int(key)]
 Base.setindex!(v::IntVector, value, key) = v.vec[v.off+Int(key)] = value
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -129,3 +129,19 @@ end
     suffixes = [UTF16(codeunits(s)[i:end]) for i in sa]
     @test issorted(suffixes)
 end
+
+@testset "Issue #15 fix part 1" begin
+    s = join(rand('a':'z', 10000)) * '\$'
+    sa = suffixsort(s)
+    suffixes = [String(codeunits(s)[i:end]) for i in sa]
+    @test issorted(suffixes)
+end
+
+@testset "Issue #15 fix part 2" begin
+    utext = rand(0x0001:0x0020, 4000)
+    sa = suffixsort(utext)
+    suffixes = [utext[i:end] for i in sa]
+    @test issorted(suffixes)
+end
+
+:done

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -130,18 +130,14 @@ end
     @test issorted(suffixes)
 end
 
-@testset "Issue #15 fix part 1" begin
+@testset "Issue #15 fix" begin
     s = join(rand('a':'z', 10000)) * '\$'
     sa = suffixsort(s)
     suffixes = [String(codeunits(s)[i:end]) for i in sa]
     @test issorted(suffixes)
-end
 
-@testset "Issue #15 fix part 2" begin
     utext = rand(0x0001:0x0020, 4000)
     sa = suffixsort(utext)
     suffixes = [utext[i:end] for i in sa]
     @test issorted(suffixes)
 end
-
-:done


### PR DESCRIPTION
Fixed size() method for IntVector -- instances created with non-zero offset were reporting an invalid size, leading to an out-of-bounds array access error.

Added two unit test to confirm correct operation to error cases reported in the issue.