### PR TITLE
Correctly reuse storage with SubArrays

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -184,3 +184,12 @@ end
     suffixes = [utext[i:end] for i in sa]
     @test issorted(suffixes)
 end
+
+@testset "Test memory consumption" begin
+    # On a random UInt8 string, with UInt32 indices, SA-IS should allocate ~4n bytes.
+    N = 10 * 1024^2             # 10 MiB
+    s = rand(UInt8, N)
+    # Avoid allocations from compilation
+    suffixsort(s)
+    @test (@allocated suffixsort(s)) < 4N * 1.05
+end


### PR DESCRIPTION
The definition of IntVector caused an implicit copy to convert SA to a Vector{Int}, negating the efforts to reuse memory.  Replace it with `@view` to get reasonable memory consumption.

Suffix sorting a 100 MiB UInt8 array (an aarch64 executable):
```
before fix   10.324155 seconds (75 allocations: 16.797 GiB, 1.12% gc time)
after fix    8.059011 seconds  (26 allocations: 400.007 MiB, 0.00% gc time)
```

Comparison with a few commonly-used suffix sorting libraries:
```
libsais      7.563240 seconds (3 allocations: 400.000 MiB, 0.00% gc time)
divsufsort   4.244779 seconds (3 allocations: 400.000 MiB, 0.00% gc time)
```